### PR TITLE
Add shared phone validation helper and tests

### DIFF
--- a/admin/password/procesar_recuperacion_cliente.php
+++ b/admin/password/procesar_recuperacion_cliente.php
@@ -1,22 +1,6 @@
 <?php
 include("../bd.php");
-
-function validarTelefono($codigo, $numero)
-{
-  $codigo = preg_replace('/[^\d]/', '', $codigo);
-  $numero = preg_replace('/[^\d]/', '', $numero);
-  $telefono = '+' . $codigo . $numero;
-
-  $longitudes = [
-    '54' => [10], '598' => [8, 9], '55' => [10, 11], '56' => [9],
-    '595' => [9], '591' => [8], '51' => [9], '1' => [10], '34' => [9]
-  ];
-
-  if (!isset($longitudes[$codigo])) return false;
-  if (!in_array(strlen($numero), $longitudes[$codigo])) return false;
-
-  return preg_match('/^\+\d{10,15}$/', $telefono) ? $telefono : false;
-}
+require_once __DIR__ . '/../../componentes/validar_telefono.php';
 ?>
 
 <!doctype html>

--- a/admin/password/recuperar_password_cliente.php
+++ b/admin/password/recuperar_password_cliente.php
@@ -1,22 +1,6 @@
 <?php
 $mensaje = "";
-
-function validarTelefono($codigo, $numero)
-{
-  $codigo = preg_replace('/[^\d]/', '', $codigo);
-  $numero = preg_replace('/[^\d]/', '', $numero);
-  $telefono = '+' . $codigo . $numero;
-
-  $longitudes = [
-    '54' => [10], '598' => [8, 9], '55' => [10, 11], '56' => [9],
-    '595' => [9], '591' => [8], '51' => [9], '1' => [10], '34' => [9]
-  ];
-
-  if (!isset($longitudes[$codigo])) return false;
-  if (!in_array(strlen($numero), $longitudes[$codigo])) return false;
-
-  return preg_match('/^\+\d{10,15}$/', $telefono) ? $telefono : false;
-}
+require_once __DIR__ . '/../../componentes/validar_telefono.php';
 ?>
 
 <!doctype html>

--- a/componentes/validar_telefono.php
+++ b/componentes/validar_telefono.php
@@ -1,0 +1,32 @@
+<?php
+
+if (!function_exists('validarTelefono')) {
+  function validarTelefono($codigo, $numero)
+  {
+    $codigo = preg_replace('/[^\d]/', '', $codigo);
+    $numero = preg_replace('/[^\d]/', '', $numero);
+    $telefono = '+' . $codigo . $numero;
+
+    $longitudes = [
+      '54' => [10],       // Argentina
+      '598' => [8, 9],    // Uruguay
+      '55' => [10, 11],   // Brasil
+      '56' => [9],        // Chile
+      '595' => [9],       // Paraguay
+      '591' => [8],       // Bolivia
+      '51' => [9],        // Perú
+      '1' => [10],        // USA
+      '34' => [9],        // España
+    ];
+
+    if (!isset($longitudes[$codigo])) {
+      return false;
+    }
+
+    if (!in_array(strlen($numero), $longitudes[$codigo], true)) {
+      return false;
+    }
+
+    return preg_match('/^\+\d{10,15}$/', $telefono) ? $telefono : false;
+  }
+}

--- a/login_cliente.php
+++ b/login_cliente.php
@@ -1,25 +1,9 @@
 <?php
 session_start();
 include("admin/bd.php");
+require_once __DIR__ . '/componentes/validar_telefono.php';
 
 $mensaje = "";
-
-function validarTelefono($codigo, $numero)
-{
-  $codigo = preg_replace('/[^\d]/', '', $codigo);
-  $numero = preg_replace('/[^\d]/', '', $numero);
-  $telefono = '+' . $codigo . $numero;
-
-  $longitudes = [
-    '54' => [10], '598' => [8, 9], '55' => [10, 11], '56' => [9],
-    '595' => [9], '591' => [8], '51' => [9], '1' => [10], '34' => [9]
-  ];
-
-  if (!isset($longitudes[$codigo])) return false;
-  if (!in_array(strlen($numero), $longitudes[$codigo])) return false;
-
-  return preg_match('/^\+\d{10,15}$/', $telefono) ? $telefono : false;
-}
 
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
   $codigo = trim($_POST["codigo_pais"] ?? "");

--- a/perfil_cliente.php
+++ b/perfil_cliente.php
@@ -1,5 +1,6 @@
 <?php
 include("admin/bd.php");
+require_once __DIR__ . '/componentes/validar_telefono.php';
 session_start();
 
 if (!isset($_SESSION["cliente"])) {
@@ -19,30 +20,6 @@ $cliente_id = $cliente["id"];
 $stmt = $conexion->prepare("SELECT nombre, telefono, email, fecha_registro, puntos FROM tbl_clientes WHERE ID = ?");
 $stmt->execute([$cliente_id]);
 $datos = $stmt->fetch(PDO::FETCH_ASSOC);
-
-function validarTelefono($codigo, $numero)
-{
-  $codigo = preg_replace('/[^\d]/', '', $codigo);
-  $numero = preg_replace('/[^\d]/', '', $numero);
-  $telefono = '+' . $codigo . $numero;
-
-  $longitudes = [
-    '54' => [10],
-    '598' => [8, 9],
-    '55' => [10, 11],
-    '56' => [9],
-    '595' => [9],
-    '591' => [8],
-    '51' => [9],
-    '1' => [10],
-    '34' => [9]
-  ];
-
-  if (!isset($longitudes[$codigo])) return false;
-  if (!in_array(strlen($numero), $longitudes[$codigo])) return false;
-
-  return preg_match('/^\+\d{10,15}$/', $telefono) ? $telefono : false;
-}
 
 // ACTUALIZAR DATOS PERSONALES
 if (isset($_POST["guardar_datos"])) {

--- a/registro_cliente.php
+++ b/registro_cliente.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 include("admin/bd.php");
+require_once __DIR__ . '/componentes/validar_telefono.php';
 
 $mensaje = "";
 
@@ -9,32 +10,6 @@ function validarFuerza($pass)
 {
   return preg_match('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}$/', $pass);
 }
-
-function validarTelefono($codigo, $numero)
-{
-  $codigo = preg_replace('/[^\d]/', '', $codigo);
-  $numero = preg_replace('/[^\d]/', '', $numero);
-  $telefono = '+' . $codigo . $numero;
-
-  // Longitudes esperadas por país
-  $longitudes = [
-    '54' => [10],       // Argentina
-    '598' => [8, 9],    // Uruguay
-    '55' => [10, 11],   // Brasil
-    '56' => [9],        // Chile
-    '595' => [9],       // Paraguay
-    '591' => [8],       // Bolivia
-    '51' => [9],        // Perú
-    '1' => [10],        // USA
-    '34' => [9]         // España
-  ];
-
-  if (!isset($longitudes[$codigo])) return false;
-  if (!in_array(strlen($numero), $longitudes[$codigo])) return false;
-
-  return preg_match('/^\+\d{10,15}$/', $telefono) ? $telefono : false;
-}
-
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
   $nombre = trim($_POST["nombre"]);

--- a/tests/ValidarTelefonoTest.php
+++ b/tests/ValidarTelefonoTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../componentes/validar_telefono.php';
+
+/**
+ * Simple assertion helper that throws when a condition is not met.
+ */
+function assertCondition(bool $condition, string $message): void
+{
+  if (!$condition) {
+    throw new RuntimeException($message);
+  }
+}
+
+try {
+  // Unsupported country codes should fail validation.
+  assertCondition(
+    validarTelefono('999', '1234567890') === false,
+    'Unsupported country code should return false.'
+  );
+
+  assertCondition(
+    validarTelefono('ABC', '1234567890') === false,
+    'Non numeric country codes should be rejected.'
+  );
+
+  // Invalid number lengths for supported country codes should fail validation.
+  $invalidLengthCases = [
+    ['54', '123456789'],      // Argentina requires 10 digits
+    ['598', '1234567'],       // Uruguay requires 8 or 9 digits
+    ['55', '123456789012'],   // Brasil allows 10 or 11 digits
+    ['56', '12345678'],       // Chile requires 9 digits
+    ['595', '12345678'],      // Paraguay requires 9 digits
+    ['591', '1234567'],       // Bolivia requires 8 digits
+    ['51', '12345678'],       // Perú requires 9 digits
+    ['1', '12345678901'],     // USA allows 10 digits
+    ['34', '12345678'],       // España requires 9 digits
+  ];
+
+  foreach ($invalidLengthCases as [$codigo, $numero]) {
+    assertCondition(
+      validarTelefono($codigo, $numero) === false,
+      "Invalid length for country code {$codigo} should return false."
+    );
+  }
+
+  // Valid cases to ensure the helper continues to work as expected.
+  $validCases = [
+    ['54', '3511234567', '+543511234567'],
+    ['598', '91234567', '+59891234567'],
+    ['598', '912345678', '+598912345678'],
+    ['55', '11987654321', '+5511987654321'],
+    ['56', '912345678', '+56912345678'],
+    ['595', '981234567', '+595981234567'],
+    ['591', '71234567', '+59171234567'],
+    ['51', '912345678', '+51912345678'],
+    ['1', '2125551234', '+12125551234'],
+    ['34', '612345678', '+34612345678'],
+  ];
+
+  foreach ($validCases as [$codigo, $numero, $esperado]) {
+    assertCondition(
+      validarTelefono($codigo, $numero) === $esperado,
+      "Valid number for country code {$codigo} should return formatted phone number."
+    );
+  }
+
+  // Ensure that extraneous characters are stripped before validation.
+  $formatted = validarTelefono('+54', '351-123 4567');
+  assertCondition(
+    $formatted === '+543511234567',
+    'The validator should strip non-digit characters before validation.'
+  );
+
+  echo "All validarTelefono tests passed.\n";
+  exit(0);
+} catch (Throwable $throwable) {
+  fwrite(STDERR, 'Test failure: ' . $throwable->getMessage() . "\n");
+  exit(1);
+}


### PR DESCRIPTION
## Summary
- extract the phone validation logic into `componentes/validar_telefono.php`
- load the shared validator in every page that relied on duplicate phone validation code
- add a CLI unit test covering unsupported country codes, invalid number lengths, and valid normalization cases

## Testing
- php tests/ValidarTelefonoTest.php

------
https://chatgpt.com/codex/tasks/task_e_68c84d4f771483238b44b1d08d27faa9