### PR TITLE
Move client auth pages into public/cliente

### DIFF
--- a/admin/password/actualizar_password.php
+++ b/admin/password/actualizar_password.php
@@ -54,7 +54,7 @@ $stmt->bindParam(":token", $token);
 $stmt->execute();
 
 echo "<div class='alert alert-success text-center'>Contraseña actualizada correctamente. Redirigiendo al login...</div>";
-echo "<script>setTimeout(() => window.location.href = '" . ($tipo === "cliente" ? "../../public/login_cliente.php" : "../login.php") . "', 3000);</script>";
+echo "<script>setTimeout(() => window.location.href = '" . ($tipo === "cliente" ? "../../public/cliente/login_cliente.php" : "../login.php") . "', 3000);</script>";
 
 echo '</div></div></div>';
 include(__DIR__ . "/../templates/footer.php");

--- a/admin/password/recuperar_password_cliente.php
+++ b/admin/password/recuperar_password_cliente.php
@@ -105,7 +105,7 @@ require_once __DIR__ . '/../../componentes/validar_telefono.php';
     </form>
 
     <div class="mt-3 text-center">
-      <a href="../../public/login_cliente.php" style="color: var(--main-gold); font-weight: bold;">Volver al login</a>
+      <a href="../../public/cliente/login_cliente.php" style="color: var(--main-gold); font-weight: bold;">Volver al login</a>
     </div>
 
     <div class="mt-4 text-center">

--- a/public/cliente/login_cliente.php
+++ b/public/cliente/login_cliente.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
-require_once __DIR__ . '/../admin/bd.php';
-require_once __DIR__ . '/../componentes/validar_telefono.php';
+require_once __DIR__ . '/../../admin/bd.php';
+require_once __DIR__ . '/../../componentes/validar_telefono.php';
 
 $mensaje = "";
 
@@ -35,7 +35,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
           "email" => $cliente["email"]
         ];
         $mensaje = "<div class='alert alert-success'>Inicio de sesión exitoso. ¡Bienvenido/a <strong>{$cliente['nombre']}</strong>!</div>";
-        $mensaje .= "<script>setTimeout(() => window.location.href = 'index.php', 1500);</script>";
+        $mensaje .= "<script>setTimeout(() => window.location.href = '../index.php', 1500);</script>";
       } else {
         $mensaje = "<div class='alert alert-danger'>Teléfono o contraseña incorrectos.</div>";
       }
@@ -55,7 +55,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
-  <link rel="icon" href="./img/favicon.png" type="image/x-icon" />
+  <link rel="icon" href="../img/favicon.png" type="image/x-icon" />
   <style>
         :root {
           --main-gold: #fac30c;
@@ -89,7 +89,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 
         .login-image {
           flex: 1;
-          background: url('img/HamLoginCliente2.jpg') center/cover no-repeat;
+          background: url('../img/HamLoginCliente2.jpg') center/cover no-repeat;
         }
 
         .login-form-wrapper {
@@ -177,7 +177,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
             position: relative;
             flex-direction: column;
             height: 100%;
-            background: url('img/HamLoginClim,jpg') center/cover no-repeat;
+            background: url('../img/HamLoginClim,jpg') center/cover no-repeat;
             background-size: cover;
             display: flex;
             justify-content: center;
@@ -275,7 +275,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
       <div class="extra-links">
         ¿No tenés cuenta? <a href="registro_cliente.php">Registrate acá</a><br><br>
         <a href="admin/password/recuperar_password_cliente.php?tipo=cliente">¿Olvidaste tu contraseña?</a><br><br>
-        <a href="index.php" class="btn btn-outline-light">← Volver al inicio</a>
+        <a href="../index.php" class="btn btn-outline-light">← Volver al inicio</a>
       </div>
     </form>
   </div>

--- a/public/cliente/logout_cliente.php
+++ b/public/cliente/logout_cliente.php
@@ -4,6 +4,6 @@ session_start();
 // Verificar si el cliente ya está autenticado
 unset($_SESSION["cliente"]);
 // Si no hay sesión de cliente, redirigir al login
-header("Location: index.php");
+header("Location: ../index.php");
 exit;
 

--- a/public/cliente/perfil_cliente.php
+++ b/public/cliente/perfil_cliente.php
@@ -1,6 +1,6 @@
 <?php
-require_once __DIR__ . '/../admin/bd.php';
-require_once __DIR__ . '/../componentes/validar_telefono.php';
+require_once __DIR__ . '/../../admin/bd.php';
+require_once __DIR__ . '/../../componentes/validar_telefono.php';
 session_start();
 
 if (!isset($_SESSION["cliente"])) {
@@ -132,7 +132,7 @@ if ($datos_guardados_exitosamente) {
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" rel="stylesheet">
 
 
-  <link rel="icon" href="./img/favicon.png" type="image/x-icon" />
+  <link rel="icon" href="../img/favicon.png" type="image/x-icon" />
 
   <style>
     :root {
@@ -153,7 +153,7 @@ if ($datos_guardados_exitosamente) {
       padding: 0;
       font-family: var(--font-main);
       color: var(--text-light);
-      background: url('img/HamLoginCliente.jpg') no-repeat center center fixed;
+      background: url('../img/HamLoginCliente.jpg') no-repeat center center fixed;
       background-size: cover;
       background-attachment: fixed;
       overflow-x: hidden;
@@ -371,11 +371,11 @@ if ($datos_guardados_exitosamente) {
 
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="./index.php">Inicio</a></li>
-          <li class="nav-item"><a class="nav-link" href="./index.php#menu">Menú</a></li>
-          
-          <li class="nav-item"><a class="nav-link" href="./index.php#nosotros">Nosotros</a></li>
-          <li class="nav-item"><a class="nav-link" href="./index.php#testimonios">Testimonio</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.php">Inicio</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.php#menu">Menú</a></li>
+
+          <li class="nav-item"><a class="nav-link" href="../index.php#nosotros">Nosotros</a></li>
+          <li class="nav-item"><a class="nav-link" href="../index.php#testimonios">Testimonio</a></li>
 
           <!-- Dropdown compacto -->
           <li class="nav-item dropdown">
@@ -383,16 +383,16 @@ if ($datos_guardados_exitosamente) {
               Más
             </a>
             <ul class="dropdown-menu dropdown-menu-dark">
-              <li><a class="dropdown-item" href="./index.php#puntos">Puntos</a></li>
-              <li><a class="dropdown-item" href="./index.php#ubicacion">Ubicación</a></li>
-              <li><a class="dropdown-item" href="./index.php#contacto">Contacto</a></li>
+              <li><a class="dropdown-item" href="../index.php#puntos">Puntos</a></li>
+              <li><a class="dropdown-item" href="../index.php#ubicacion">Ubicación</a></li>
+              <li><a class="dropdown-item" href="../index.php#contacto">Contacto</a></li>
 
             </ul>
           </li>
 
         <!-- Carrito -->
         <li class="nav-item">
-          <a class="nav-link position-relative" href="carrito.php">
+          <a class="nav-link position-relative" href="../carrito.php">
             <i class="fas fa-shopping-cart"></i>
             <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="contador-carrito" style="font-size: 0.7rem;">
               0
@@ -731,7 +731,7 @@ value="<?= isset($cliente['telefono']) ? preg_replace('/^\+\d+/', '', $cliente['
 
   async function actualizarHistorial() {
     try {
-      const response = await fetch('admin/obtener_pedidos_cliente.php');
+      const response = await fetch('../admin/obtener_pedidos_cliente.php');
       const pedidos = await response.json();
 
       const historialContenedor = document.getElementById('historial-pedidos');
@@ -800,11 +800,11 @@ const pedidoId = pedido.id ?? (pedidos.length - index);
 </script>
 
 
-  <?php include("componentes/whatsapp_button.php"); ?>
+  <?php include __DIR__ . '/../../componentes/whatsapp_button.php'; ?>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 
-  <?php include("componentes/carrito_button.php"); ?>
+  <?php include __DIR__ . '/../../componentes/carrito_button.php'; ?>
 
   <!-- Modal de cierre de sesión -->
   <div class="modal fade" id="logoutModal" tabindex="-1" aria-labelledby="logoutModalLabel" aria-hidden="true">

--- a/public/cliente/registro_cliente.php
+++ b/public/cliente/registro_cliente.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
-require_once __DIR__ . '/../admin/bd.php';
-require_once __DIR__ . '/../componentes/validar_telefono.php';
+require_once __DIR__ . '/../../admin/bd.php';
+require_once __DIR__ . '/../../componentes/validar_telefono.php';
 
 $mensaje = "";
 
@@ -61,7 +61,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="icon" href="./img/favicon.png" type="image/x-icon" />
+  <link rel="icon" href="../img/favicon.png" type="image/x-icon" />
 
   <style>
     :root {
@@ -102,7 +102,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     .register-image {
       flex: 1;
-      background: url('img/HamLoginCliente.jpg') center/cover no-repeat;
+      background: url('../img/HamLoginCliente.jpg') center/cover no-repeat;
       background-size: cover;
       min-height: 100%;
     }
@@ -212,7 +212,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     @media (max-width: 768px) {
   .register-container {
     flex-direction: column;
-    background: url('./img/HamLoginCliente.jpg') center/cover no-repeat;
+    background: url('../img/HamLoginCliente.jpg') center/cover no-repeat;
     background-size: cover;
     min-height: 100vh;
     padding-top: 40px;
@@ -293,7 +293,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
         <div class="extra-links">
           ¿Ya tenés cuenta? <a href="./login_cliente.php">Iniciar sesión</a><br><br>
-          <a href="index.php" class="btn btn-outline-light">← Volver a la página principal</a>
+          <a href="../index.php" class="btn btn-outline-light">← Volver a la página principal</a>
         </div>
       </form>
     </div>

--- a/views/carrito.view.php
+++ b/views/carrito.view.php
@@ -51,7 +51,7 @@
 
           <?php if (isset($_SESSION["cliente"])): ?>
             <li class="nav-item">
-              <a href="perfil_cliente.php" class="nav-link" title="<?= htmlspecialchars($_SESSION["cliente"]["nombre"]) ?>">
+              <a href="cliente/perfil_cliente.php" class="nav-link" title="<?= htmlspecialchars($_SESSION["cliente"]["nombre"]) ?>">
                 <i class="fas fa-user-circle"></i>
               </a>
             </li>
@@ -63,7 +63,7 @@
             </li>
           <?php else: ?>
             <li class="nav-item">
-              <a href="login_cliente.php" class="btn btn-gold rounded-pill px-4 py-2 ms-2">
+              <a href="cliente/login_cliente.php" class="btn btn-gold rounded-pill px-4 py-2 ms-2">
                 Iniciar sesión / Registrarse
               </a>
             </li>
@@ -89,7 +89,7 @@
           <button type="button" class="btn btn-success px-4" data-bs-dismiss="modal">
             <i></i> Quedarme
           </button>
-          <a href="./logout_cliente.php" class="btn btn-danger px-4">
+          <a href="cliente/logout_cliente.php" class="btn btn-danger px-4">
             <i class="fas fa-door-open me-1"></i> Cerrar Sesión
           </a>
         </div>

--- a/views/index.view.php
+++ b/views/index.view.php
@@ -66,7 +66,7 @@
           <!-- Sesión -->
           <?php if (isset($_SESSION["cliente"])): ?>
             <li class="nav-item">
-              <a href="perfil_cliente.php" class="nav-link" title="<?= htmlspecialchars($_SESSION["cliente"]["nombre"]) ?>">
+              <a href="cliente/perfil_cliente.php" class="nav-link" title="<?= htmlspecialchars($_SESSION["cliente"]["nombre"]) ?>">
                 <i class="fas fa-user-circle"></i>
               </a>
             </li>
@@ -78,7 +78,7 @@
             </li>
           <?php else: ?>
             <li class="nav-item">
-              <a href="login_cliente.php" class="btn btn-gold rounded-pill px-4 py-2 ms-2">
+              <a href="cliente/login_cliente.php" class="btn btn-gold rounded-pill px-4 py-2 ms-2">
                 Iniciar sesión / Registrarse
               </a>
             </li>
@@ -98,7 +98,7 @@
         Acumulá <strong class="text-gold">puntos exclusivos</strong> en cada compra y canjealos por <strong>descuentos irresistibles</strong>.
       </p>
 
-      <a href="registro_cliente.php" class="btn btn-gold w-100 mt-2">Registrarse</a>
+      <a href="cliente/registro_cliente.php" class="btn btn-gold w-100 mt-2">Registrarse</a>
     </div>
   <?php endif; ?>
 
@@ -391,7 +391,7 @@
           <button type="button" class="btn btn-success px-4" data-bs-dismiss="modal">
             <i></i> Quedarme
           </button>
-          <a href="./logout_cliente.php" class="btn btn-danger px-4">
+          <a href="cliente/logout_cliente.php" class="btn btn-danger px-4">
             <i class="fas fa-door-open me-1"></i> Cerrar Sesión
           </a>
         </div>


### PR DESCRIPTION
## Summary
- move the client login, logout, profile and registration scripts into a dedicated `public/cliente` directory and fix their relative resource paths
- update frontend views and admin password recovery pages to reference the new client routes

## Testing
- php -l public/cliente/login_cliente.php
- php -l public/cliente/logout_cliente.php
- php -l public/cliente/perfil_cliente.php
- php -l public/cliente/registro_cliente.php
- php -l admin/password/actualizar_password.php
- php -l admin/password/recuperar_password_cliente.php
- php -l views/index.view.php
- php -l views/carrito.view.php

------
https://chatgpt.com/codex/tasks/task_e_68c880e023808323b3df89aebfd6c111