### PR TITLE
refactor: centralize admin datatables assets

### DIFF
--- a/admin/assets/css/datatables-custom.css
+++ b/admin/assets/css/datatables-custom.css
@@ -1,0 +1,35 @@
+/* Shared responsive adjustments for DataTables controls */
+@media (max-width: 576px) {
+  .dataTables_wrapper .dataTables_filter,
+  .dataTables_wrapper .dataTables_length {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .dataTables_wrapper .dataTables_filter input,
+  .dataTables_wrapper .dataTables_length select {
+    width: 100% !important;
+  }
+
+  .dataTables_wrapper .dataTables_paginate {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .dataTables_length label {
+    font-weight: 500;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+}
+
+@media (min-width: 576px) {
+  .dataTables_length label {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}

--- a/admin/assets/js/datatables-init.js
+++ b/admin/assets/js/datatables-init.js
@@ -1,0 +1,59 @@
+(function (global) {
+  'use strict';
+
+  var defaultOptions = {
+    paging: true,
+    searching: true,
+    info: false,
+    lengthChange: true,
+    responsive: true,
+    fixedHeader: true,
+    language: {
+      decimal: "",
+      emptyTable: "No hay datos disponibles en la tabla",
+      info: "Mostrando _START_ a _END_ de _TOTAL_ registros",
+      infoEmpty: "Mostrando 0 a 0 de 0 registros",
+      infoFiltered: "(filtrado de _MAX_ registros totales)",
+      lengthMenu: "Mostrar registros: _MENU_",
+      loadingRecords: "Cargando...",
+      processing: "Procesando...",
+      search: "Buscar:",
+      zeroRecords: "No se encontraron registros coincidentes",
+      paginate: {
+        first: "Primero",
+        last: "Último",
+        next: "Siguiente",
+        previous: "Anterior"
+      },
+      aria: {
+        sortAscending: ": activar para ordenar la columna ascendente",
+        sortDescending: ": activar para ordenar la columna descendente"
+      }
+    }
+  };
+
+  function initDataTable(selector, options) {
+    var $ = global.jQuery;
+    if (!$ || !$.fn || !$.fn.DataTable) {
+      if (global.console && typeof global.console.warn === 'function') {
+        console.warn('initDataTable requiere que jQuery y DataTables estén cargados.');
+      }
+      return null;
+    }
+
+    var $table = selector && selector.jquery ? selector : $(selector);
+
+    if (!$table || !$table.length) {
+      return null;
+    }
+
+    if ($.fn.DataTable.isDataTable($table)) {
+      $table.DataTable().clear().destroy();
+    }
+
+    var settings = $.extend(true, {}, defaultOptions, options || {});
+    return $table.DataTable(settings);
+  }
+
+  global.initDataTable = initDataTable;
+})(window);

--- a/admin/clientes.php
+++ b/admin/clientes.php
@@ -9,43 +9,6 @@ $lista_clientes = $sentencia->fetchAll(PDO::FETCH_ASSOC);
 include("../admin/templates/header.php");
 ?>
 
-<style>
-  @media (max-width: 576px) {
-    .dataTables_wrapper .dataTables_filter,
-    .dataTables_wrapper .dataTables_length {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-    }
-
-    .dataTables_wrapper .dataTables_filter input,
-    .dataTables_wrapper .dataTables_length select {
-      width: 100% !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate {
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-
-    .dataTables_length label {
-      font-weight: 500;
-      display: flex;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-  }
-
-  @media (min-width: 576px) {
-    .dataTables_length label {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      gap: 0.5rem;
-    }
-  }
-</style>
-
 <br>
 <div class="card">
   <div class="card-header">
@@ -82,44 +45,9 @@ include("../admin/templates/header.php");
   <div class="card-footer text-muted"></div>
 </div>
 
-<!-- DataTables JS -->
-<script src="https://cdn.datatables.net/1.13.2/js/jquery.dataTables.min.js"></script>
 <script>
-  $(document).ready(function () {
-    if ($.fn.DataTable.isDataTable('#tablaClientes')) {
-      $('#tablaClientes').DataTable().clear().destroy();
-    }
-
-    $('#tablaClientes').DataTable({
-      paging: true,
-      searching: true,
-      info: false,
-      lengthChange: true,
-      responsive: true,
-      fixedHeader: true,
-      language: {
-        decimal: "",
-        emptyTable: "No hay datos disponibles en la tabla",
-        info: "Mostrando _START_ a _END_ de _TOTAL_ registros",
-        infoEmpty: "Mostrando 0 a 0 de 0 registros",
-        infoFiltered: "(filtrado de _MAX_ registros totales)",
-        lengthMenu: "Mostrar registros: _MENU_",
-        loadingRecords: "Cargando...",
-        processing: "Procesando...",
-        search: "Buscar:",
-        zeroRecords: "No se encontraron registros coincidentes",
-        paginate: {
-          first: "Primero",
-          last: "Último",
-          next: "Siguiente",
-          previous: "Anterior"
-        },
-        aria: {
-          sortAscending: ": activar para ordenar la columna ascendente",
-          sortDescending: ": activar para ordenar la columna descendente"
-        }
-      }
-    });
+  document.addEventListener('DOMContentLoaded', function () {
+    initDataTable('#tablaClientes');
   });
 </script>
 

--- a/admin/panel_cocina.php
+++ b/admin/panel_cocina.php
@@ -9,50 +9,14 @@ $pedidos = $sentencia->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
 <style>
-  @media (max-width: 576px) {
-    .dataTables_wrapper .dataTables_filter,
-    .dataTables_wrapper .dataTables_length {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-    }
-
-    .dataTables_wrapper .dataTables_filter input,
-    .dataTables_wrapper .dataTables_length select {
-      width: 100% !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate {
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-
-    .dataTables_length label {
-      font-weight: 500;
-      display: flex;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-  }
-
   tr.en-camino {
     background-color: #fff3cd !important;
   }
 
   .camion-icono {
-  font-size: 1.2rem;
-  margin-right: 4px;
-  display: inline-block;
-}
-
-
-  @media (min-width: 576px) {
-    .dataTables_length label {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      gap: 0.5rem;
-    }
+    font-size: 1.2rem;
+    margin-right: 4px;
+    display: inline-block;
   }
 </style>
 
@@ -126,45 +90,9 @@ $pedidos = $sentencia->fetchAll(PDO::FETCH_ASSOC);
   </div>
 </div>
 
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<!-- DataTables JS -->
-<script src="https://cdn.datatables.net/1.13.2/js/jquery.dataTables.min.js"></script>
 <script>
-  $(document).ready(function () {
-    if ($.fn.DataTable.isDataTable('#tabla-pedidos')) {
-      $('#tabla-pedidos').DataTable().clear().destroy();
-    }
-
-    $('#tabla-pedidos').DataTable({
-      paging: true,
-      searching: true,
-      info: false,
-      lengthChange: true,
-      responsive: true,
-      fixedHeader: true,
-      language: {
-        decimal: "",
-        emptyTable: "No hay datos disponibles en la tabla",
-        info: "Mostrando _START_ a _END_ de _TOTAL_ registros",
-        infoEmpty: "Mostrando 0 a 0 de 0 registros",
-        infoFiltered: "(filtrado de _MAX_ registros totales)",
-        lengthMenu: "Mostrar registros: _MENU_",
-        loadingRecords: "Cargando...",
-        processing: "Procesando...",
-        search: "Buscar:",
-        zeroRecords: "No se encontraron registros coincidentes",
-        paginate: {
-          first: "Primero",
-          last: "Último",
-          next: "Siguiente",
-          previous: "Anterior"
-        },
-        aria: {
-          sortAscending: ": activar para ordenar la columna ascendente",
-          sortDescending: ": activar para ordenar la columna descendente"
-        }
-      }
-    });
+  document.addEventListener('DOMContentLoaded', function () {
+    initDataTable('#tabla-pedidos');
   });
 
   async function actualizarEstado(pedidoId, nuevoEstado, boton) {

--- a/admin/seccion/banners/index.php
+++ b/admin/seccion/banners/index.php
@@ -18,44 +18,6 @@ $lista_banners = $sentencia->fetchAll(PDO::FETCH_ASSOC);
 include("../../templates/header.php");
 ?>
 
-<style>
-  @media (max-width: 576px) {
-    .dataTables_wrapper .dataTables_filter,
-    .dataTables_wrapper .dataTables_length {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-    }
-
-    .dataTables_length {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 0.25rem;
-}
-
-.dataTables_length label {
-  font-weight: 500;
-}
-
-.dataTables_length select {
-  width: auto;
-  min-width: 80px;
-}
-
-
-    .dataTables_wrapper .dataTables_filter input,
-    .dataTables_wrapper .dataTables_length select {
-      width: 100% !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate {
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-  }
-</style>
-
 <br />
 <div class="card">
   <div class="card-header">
@@ -97,46 +59,9 @@ include("../../templates/header.php");
   <div class="card-footer text-muted"></div>
 </div>
 
-<!-- DataTables JS -->
-<script src="https://cdn.datatables.net/1.13.2/js/jquery.dataTables.min.js"></script>
 <script>
-  $(document).ready(function () {
-    if ($.fn.DataTable.isDataTable('#miTabla')) {
-      $('#miTabla').DataTable().clear().destroy();
-    }
-
-    $('#miTabla').DataTable({
-      paging: true,
-      searching: true,
-      info: false,
-      lengthChange: true,
-      responsive: true,
-      fixedHeader: true,
-      language: {
-  lengthMenu: "Mostrar registros: _MENU_",
-  decimal: "",
-  emptyTable: "No hay datos disponibles en la tabla",
-  info: "Mostrando _START_ a _END_ de _TOTAL_ registros",
-  infoEmpty: "Mostrando 0 a 0 de 0 registros",
-  infoFiltered: "(filtrado de _MAX_ registros totales)",
-  loadingRecords: "Cargando...",
-  processing: "Procesando...",
-  search: "Buscar:",
-  zeroRecords: "No se encontraron registros coincidentes",
-  paginate: {
-    first: "Primero",
-    last: "Último",
-    next: "Siguiente",
-    previous: "Anterior"
-  },
-  aria: {
-    sortAscending: ": activar para ordenar la columna ascendente",
-    sortDescending: ": activar para ordenar la columna descendente"
-  }
-}
-
-
-    });
+  document.addEventListener('DOMContentLoaded', function () {
+    initDataTable('#miTabla');
   });
 </script>
 

--- a/admin/seccion/comentarios/index.php
+++ b/admin/seccion/comentarios/index.php
@@ -18,43 +18,6 @@ $lista_comentarios = $sentencia->fetchAll(PDO::FETCH_ASSOC);
 include("../../templates/header.php");
 ?>
 
-<style>
-  @media (max-width: 576px) {
-    .dataTables_wrapper .dataTables_filter,
-    .dataTables_wrapper .dataTables_length {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-    }
-
-    .dataTables_wrapper .dataTables_filter input,
-    .dataTables_wrapper .dataTables_length select {
-      width: 100% !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate {
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-
-    .dataTables_length label {
-      font-weight: 500;
-      display: flex;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-  }
-
-  @media (min-width: 576px) {
-    .dataTables_length label {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      gap: 0.5rem;
-    }
-  }
-</style>
-
 <br />
 <div class="card">
   <div class="card-header">
@@ -91,44 +54,9 @@ include("../../templates/header.php");
   <div class="card-footer text-muted"></div>
 </div>
 
-<!-- DataTables JS -->
-<script src="https://cdn.datatables.net/1.13.2/js/jquery.dataTables.min.js"></script>
 <script>
-  $(document).ready(function () {
-    if ($.fn.DataTable.isDataTable('#tablaComentarios')) {
-      $('#tablaComentarios').DataTable().clear().destroy();
-    }
-
-    $('#tablaComentarios').DataTable({
-      paging: true,
-      searching: true,
-      info: false,
-      lengthChange: true,
-      responsive: true,
-      fixedHeader: true,
-      language: {
-        decimal: "",
-        emptyTable: "No hay datos disponibles en la tabla",
-        info: "Mostrando _START_ a _END_ de _TOTAL_ registros",
-        infoEmpty: "Mostrando 0 a 0 de 0 registros",
-        infoFiltered: "(filtrado de _MAX_ registros totales)",
-        lengthMenu: "Mostrar registros: _MENU_",
-        loadingRecords: "Cargando...",
-        processing: "Procesando...",
-        search: "Buscar:",
-        zeroRecords: "No se encontraron registros coincidentes",
-        paginate: {
-          first: "Primero",
-          last: "Último",
-          next: "Siguiente",
-          previous: "Anterior"
-        },
-        aria: {
-          sortAscending: ": activar para ordenar la columna ascendente",
-          sortDescending: ": activar para ordenar la columna descendente"
-        }
-      }
-    });
+  document.addEventListener('DOMContentLoaded', function () {
+    initDataTable('#tablaComentarios');
   });
 </script>
 

--- a/admin/seccion/testimonios/index.php
+++ b/admin/seccion/testimonios/index.php
@@ -21,43 +21,6 @@ $lista_testimonios = $sentencia->fetchAll(PDO::FETCH_ASSOC);
 include("../../templates/header.php");
 ?>
 
-<style>
-  @media (max-width: 576px) {
-    .dataTables_wrapper .dataTables_filter,
-    .dataTables_wrapper .dataTables_length {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-    }
-
-    .dataTables_wrapper .dataTables_filter input,
-    .dataTables_wrapper .dataTables_length select {
-      width: 100% !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate {
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-
-    .dataTables_length label {
-      font-weight: 500;
-      display: flex;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-  }
-
-  @media (min-width: 576px) {
-    .dataTables_length label {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      gap: 0.5rem;
-    }
-  }
-</style>
-
 <br />
 <div class="card">
   <div class="card-header">
@@ -93,44 +56,9 @@ include("../../templates/header.php");
   <div class="card-footer text-muted"></div>
 </div>
 
-<!-- DataTables JS -->
-<script src="https://cdn.datatables.net/1.13.2/js/jquery.dataTables.min.js"></script>
 <script>
-  $(document).ready(function () {
-    if ($.fn.DataTable.isDataTable('#tablaTestimonios')) {
-      $('#tablaTestimonios').DataTable().clear().destroy();
-    }
-
-    $('#tablaTestimonios').DataTable({
-      paging: true,
-      searching: true,
-      info: false,
-      lengthChange: true,
-      responsive: true,
-      fixedHeader: true,
-      language: {
-        decimal: "",
-        emptyTable: "No hay datos disponibles en la tabla",
-        info: "Mostrando _START_ a _END_ de _TOTAL_ registros",
-        infoEmpty: "Mostrando 0 a 0 de 0 registros",
-        infoFiltered: "(filtrado de _MAX_ registros totales)",
-        lengthMenu: "Mostrar registros: _MENU_",
-        loadingRecords: "Cargando...",
-        processing: "Procesando...",
-        search: "Buscar:",
-        zeroRecords: "No se encontraron registros coincidentes",
-        paginate: {
-          first: "Primero",
-          last: "Último",
-          next: "Siguiente",
-          previous: "Anterior"
-        },
-        aria: {
-          sortAscending: ": activar para ordenar la columna ascendente",
-          sortDescending: ": activar para ordenar la columna descendente"
-        }
-      }
-    });
+  document.addEventListener('DOMContentLoaded', function () {
+    initDataTable('#tablaTestimonios');
   });
 </script>
 

--- a/admin/seccion/usuarios/index.php
+++ b/admin/seccion/usuarios/index.php
@@ -47,43 +47,6 @@ $lista_usuarios = $sentencia->fetchAll(PDO::FETCH_ASSOC);
 include("../../templates/header.php");
 ?>
 
-<style>
-  @media (max-width: 576px) {
-    .dataTables_wrapper .dataTables_filter,
-    .dataTables_wrapper .dataTables_length {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-    }
-
-    .dataTables_wrapper .dataTables_filter input,
-    .dataTables_wrapper .dataTables_length select {
-      width: 100% !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate {
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-
-    .dataTables_length label {
-      font-weight: 500;
-      display: flex;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-  }
-
-  @media (min-width: 576px) {
-    .dataTables_length label {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      gap: 0.5rem;
-    }
-  }
-</style>
-
 <br>
 <div class="card">
   <div class="card-header">
@@ -142,41 +105,8 @@ include("../../templates/header.php");
 </div>
 
 <script>
-  $(document).ready(function () {
-    if ($.fn.DataTable.isDataTable('#tablaUsuarios')) {
-      $('#tablaUsuarios').DataTable().clear().destroy();
-    }
-
-    $('#tablaUsuarios').DataTable({
-      paging: true,
-      searching: true,
-      info: false,
-      lengthChange: true,
-      responsive: true,
-      fixedHeader: true,
-      language: {
-        decimal: "",
-        emptyTable: "No hay datos disponibles en la tabla",
-        info: "Mostrando _START_ a _END_ de _TOTAL_ registros",
-        infoEmpty: "Mostrando 0 a 0 de 0 registros",
-        infoFiltered: "(filtrado de _MAX_ registros totales)",
-        lengthMenu: "Mostrar registros: _MENU_",
-        loadingRecords: "Cargando...",
-        processing: "Procesando...",
-        search: "Buscar:",
-        zeroRecords: "No se encontraron registros coincidentes",
-        paginate: {
-          first: "Primero",
-          last: "Último",
-          next: "Siguiente",
-          previous: "Anterior"
-        },
-        aria: {
-          sortAscending: ": activar para ordenar la columna ascendente",
-          sortDescending: ": activar para ordenar la columna descendente"
-        }
-      }
-    });
+  document.addEventListener('DOMContentLoaded', function () {
+    initDataTable('#tablaUsuarios');
   });
 </script>
 

--- a/admin/templates/header.php
+++ b/admin/templates/header.php
@@ -33,12 +33,16 @@ $rol = $_SESSION["rol"] ?? "";
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="icon" type="image/png" href="<?php echo $url_base; ?>../public/img/favicon.png" />
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.2/css/jquery.dataTables.min.css">
+  <link rel="stylesheet" href="<?php echo $url_base; ?>assets/css/datatables-custom.css">
 
   <style>
     .dropdown-menu {
       z-index: 1050;
     }
   </style>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.2/js/jquery.dataTables.min.js"></script>
+  <script src="<?php echo $url_base; ?>assets/js/datatables-init.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- add shared DataTables stylesheet and initializer for admin pages
- update admin listing pages to load the shared assets
- load jQuery, DataTables, and the new helper through the admin header

## Testing
- php -l admin/clientes.php
- php -l admin/seccion/usuarios/index.php
- php -l admin/seccion/testimonios/index.php
- php -l admin/seccion/comentarios/index.php
- php -l admin/seccion/banners/index.php
- php -l admin/panel_cocina.php
- php -l admin/templates/header.php

------
https://chatgpt.com/codex/tasks/task_e_68c88b6401e48323ab7609b9d30bcf28