### PR TITLE
Refactor shared head and navigation into partials

### DIFF
--- a/views/carrito.view.php
+++ b/views/carrito.view.php
@@ -2,100 +2,21 @@
 <html lang="es">
 
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Carrito - Piccolo Burgers</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="icon" href="./img/favicon.png" type="image/x-icon" />
-  <link rel="stylesheet" href="assets/css/carrito.css">
+  <?php
+  $pageTitle = 'Carrito - Piccolo Burgers';
+  $extraCss = [
+    'assets/css/carrito.css',
+  ];
+  include __DIR__ . '/partials/head.php';
+  ?>
 </head>
 
 <body>
-  <nav class="navbar navbar-expand-lg navbar-dark sticky-navbar bg-dark">
-    <div class="container">
-      <a class="navbar-brand" href="#"><i class="fas fa-utensils"></i> Piccolo Burgers</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="./index.php">Inicio</a></li>
-          <li class="nav-item"><a class="nav-link" href="./index.php#menu">Menú</a></li>
-          <li class="nav-item"><a class="nav-link" href="./index.php#nosotros">Nosotros</a></li>
-          <li class="nav-item"><a class="nav-link" href="./index.php#testimonio">Testimonio</a></li>
-
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="extrasDropdown" role="button" data-bs-toggle="dropdown">
-              Más
-            </a>
-            <ul class="dropdown-menu dropdown-menu-dark">
-              <li><a class="dropdown-item" href="./index.php#puntos">Puntos</a></li>
-              <li><a class="dropdown-item" href="./index.php#ubicacion">Ubicación</a></li>
-              <li><a class="dropdown-item" href="./index.php#contacto">Contacto</a></li>
-
-            </ul>
-          </li>
-
-          <li class="nav-item">
-            <a class="nav-link position-relative" href="carrito.php">
-              <i class="fas fa-shopping-cart"></i>
-              <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="contador-carrito" style="font-size: 0.7rem;">
-                0
-              </span>
-            </a>
-          </li>
-
-          <?php if (isset($_SESSION["cliente"])): ?>
-            <li class="nav-item">
-              <a href="cliente/perfil_cliente.php" class="nav-link" title="<?= htmlspecialchars($_SESSION["cliente"]["nombre"]) ?>">
-                <i class="fas fa-user-circle"></i>
-              </a>
-            </li>
-            <li class="nav-item">
-              <a href="#" class="nav-link" title="Cerrar sesión" data-bs-toggle="modal" data-bs-target="#logoutModal">
-                <i class="fas fa-sign-out-alt"></i>
-              </a>
-
-            </li>
-          <?php else: ?>
-            <li class="nav-item">
-              <a href="cliente/login_cliente.php" class="btn btn-gold rounded-pill px-4 py-2 ms-2">
-                Iniciar sesión / Registrarse
-              </a>
-            </li>
-          <?php endif; ?>
-        </ul>
-      </div>
-    </div>
-  </nav>
-
-  <div class="modal fade" id="logoutModal" tabindex="-1" aria-labelledby="logoutModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content bg-dark text-white border-0 shadow-lg">
-        <div class="modal-header border-bottom-0">
-          <h5 class="modal-title fw-bold" id="logoutModalLabel">
-            <i class="fas fa-sign-out-alt me-2 text-warning"></i> ¿Cerrar sesión?
-          </h5>
-          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Cerrar"></button>
-        </div>
-        <div class="modal-body text-center">
-          <p class="fs-5 mb-0">¿Estás seguro de que querés cerrar sesión?</p>
-        </div>
-        <div class="modal-footer justify-content-center border-top-0">
-          <button type="button" class="btn btn-success px-4" data-bs-dismiss="modal">
-            <i></i> Quedarme
-          </button>
-          <a href="cliente/logout_cliente.php" class="btn btn-danger px-4">
-            <i class="fas fa-door-open me-1"></i> Cerrar Sesión
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
+  <?php
+  $navBasePath = './index.php';
+  $navHomeLink = './index.php';
+  include __DIR__ . '/partials/navbar.php';
+  ?>
 
   <div class="container contenido-ajustado">
     <div class="container">

--- a/views/confirmar_pedido.view.php
+++ b/views/confirmar_pedido.view.php
@@ -2,26 +2,26 @@
 <html lang="es">
 
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Confirmar Pedido - Piccolo Burgers</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-  <link rel="icon" href="./img/favicon.png" type="image/x-icon" />
-  <link rel="stylesheet" href="assets/css/confirmar_pedido.css">
+  <?php
+  $pageTitle = 'Confirmar Pedido - Piccolo Burgers';
+  $extraCss = [
+    'assets/css/confirmar_pedido.css',
+  ];
+  include __DIR__ . '/partials/head.php';
+  ?>
 </head>
 
 <body>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <div class="container">
-      <a class="navbar-brand" href="index.php"><i class="fas fa-utensils"></i> PICCOLO BURGERS</a>
-      <a class="btn btn-gold ms-auto" href="carrito.php"><i class="fas fa-chevron-left"></i> Volver</a>
-    </div>
-  </nav>
+  <?php
+  $navBasePath = 'index.php';
+  $navHomeLink = 'index.php';
+  include __DIR__ . '/partials/navbar.php';
+  ?>
 
   <div class="container mt-5">
+    <div class="d-flex justify-content-end mb-3">
+      <a class="btn btn-gold" href="carrito.php"><i class="fas fa-chevron-left"></i> Volver</a>
+    </div>
     <h2 class="mb-4 text-center">Confirmar Pedido</h2>
 
     <form id="form-pedido" method="post">

--- a/views/index.view.php
+++ b/views/index.view.php
@@ -2,91 +2,28 @@
 <html lang="en">
 
 <head>
-  <title>Piccolo Burgers</title>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600&display=swap" rel="stylesheet">
-
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" rel="stylesheet">
-  <link rel="icon" href="./img/favicon.png" type="image/x-icon" />
-
+  <?php
+  $pageTitle = 'Piccolo Burgers';
+  $extraCss = [
+    'https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css',
+    'assets/css/custom.css',
+    'assets/css/index.css',
+  ];
+  include __DIR__ . '/partials/head.php';
+  ?>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
-
-  <!-- AOS CSS -->
-  <link href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/custom.css">
-  <link rel="stylesheet" href="assets/css/index.css">
 
 </head>
 
 <body id="top">
 
-  <nav class="navbar navbar-expand-lg navbar-dark sticky-navbar bg-dark">
-    <div class="container">
-      <a class="navbar-brand" href="#"><i class="fas fa-utensils"></i> Piccolo Burgers</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <!-- Enlaces principales -->
-          <li class="nav-item"><a class="nav-link" href="#inicio">Inicio</a></li>
-          <li class="nav-item"><a class="nav-link" href="#menu">Menú</a></li>
-          <li class="nav-item"><a class="nav-link" href="#nosotros">Nosotros</a></li>
-          <li class="nav-item"><a class="nav-link" href="#testimonios">Testimonio</a></li>
-
-          <!-- Dropdown compacto -->
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="extrasDropdown" role="button" data-bs-toggle="dropdown">
-              Más
-            </a>
-            <ul class="dropdown-menu dropdown-menu-dark">
-              <li><a class="dropdown-item" href="#puntos">Puntos</a></li>
-              <li><a class="dropdown-item" href="#ubicacion">Ubicación</a></li>
-              <li><a class="dropdown-item" href="#contacto">Contacto</a></li>
-            </ul>
-          </li>
-
-          <!-- Carrito -->
-          <li class="nav-item">
-            <a class="nav-link position-relative" href="carrito.php">
-              <i class="fas fa-shopping-cart"></i>
-              <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger cart-counter" id="contador-carrito">
-                0
-              </span>
-            </a>
-          </li>
-
-          <!-- Sesión -->
-          <?php if (isset($_SESSION["cliente"])): ?>
-            <li class="nav-item">
-              <a href="cliente/perfil_cliente.php" class="nav-link" title="<?= htmlspecialchars($_SESSION["cliente"]["nombre"]) ?>">
-                <i class="fas fa-user-circle"></i>
-              </a>
-            </li>
-            <li class="nav-item">
-              <a href="#" class="nav-link" title="Cerrar sesión" data-bs-toggle="modal" data-bs-target="#logoutModal">
-                <i class="fas fa-sign-out-alt"></i>
-              </a>
-
-            </li>
-          <?php else: ?>
-            <li class="nav-item">
-              <a href="cliente/login_cliente.php" class="btn btn-gold rounded-pill px-4 py-2 ms-2">
-                Iniciar sesión / Registrarse
-              </a>
-            </li>
-          <?php endif; ?>
-        </ul>
-      </div>
-    </div>
-  </nav>
+  <?php
+  $navBasePath = '';
+  $navHomeLink = '#';
+  include __DIR__ . '/partials/navbar.php';
+  ?>
 
 
   <?php if (!isset($_SESSION["cliente"])): ?>
@@ -370,31 +307,6 @@
           Producto <span id="toastProductoNombre"></span> agregado al carrito.
         </div>
         <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Cerrar"></button>
-      </div>
-    </div>
-  </div>
-
-  <!-- Modal de cierre de sesión -->
-  <div class="modal fade" id="logoutModal" tabindex="-1" aria-labelledby="logoutModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content bg-dark text-white border-0 shadow-lg">
-        <div class="modal-header border-bottom-0">
-          <h5 class="modal-title fw-bold" id="logoutModalLabel">
-            <i class="fas fa-sign-out-alt me-2 text-warning"></i> ¿Cerrar sesión?
-          </h5>
-          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Cerrar"></button>
-        </div>
-        <div class="modal-body text-center">
-          <p class="fs-5 mb-0">¿Estás seguro de que querés cerrar sesión?</p>
-        </div>
-        <div class="modal-footer justify-content-center border-top-0">
-          <button type="button" class="btn btn-success px-4" data-bs-dismiss="modal">
-            <i></i> Quedarme
-          </button>
-          <a href="cliente/logout_cliente.php" class="btn btn-danger px-4">
-            <i class="fas fa-door-open me-1"></i> Cerrar Sesión
-          </a>
-        </div>
       </div>
     </div>
   </div>

--- a/views/partials/head.php
+++ b/views/partials/head.php
@@ -1,0 +1,21 @@
+<?php
+$pageTitle = isset($pageTitle) ? (string) $pageTitle : 'Piccolo Burgers';
+$extraCss = $extraCss ?? [];
+
+if (!is_array($extraCss)) {
+    $extraCss = [$extraCss];
+}
+?>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?= htmlspecialchars($pageTitle, ENT_QUOTES, 'UTF-8'); ?></title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600&display=swap" rel="stylesheet">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" rel="stylesheet">
+<link rel="icon" href="./img/favicon.png" type="image/x-icon" />
+<?php foreach ($extraCss as $cssFile): ?>
+  <?php if (is_string($cssFile) && $cssFile !== ''): ?>
+    <link rel="stylesheet" href="<?= htmlspecialchars($cssFile, ENT_QUOTES, 'UTF-8'); ?>">
+  <?php endif; ?>
+<?php endforeach; ?>

--- a/views/partials/navbar.php
+++ b/views/partials/navbar.php
@@ -1,0 +1,103 @@
+<?php
+$navBasePath = isset($navBasePath) ? (string) $navBasePath : '';
+$navHomeLink = isset($navHomeLink) ? (string) $navHomeLink : ($navBasePath !== '' ? $navBasePath : '#');
+$navBrandLabel = isset($navBrandLabel) ? (string) $navBrandLabel : 'Piccolo Burgers';
+$navCarritoLink = isset($navCarritoLink) ? (string) $navCarritoLink : 'carrito.php';
+
+$navSectionBase = $navBasePath !== '' ? rtrim($navBasePath, '#') : '';
+$sectionLinkPrefix = $navSectionBase !== '' ? $navSectionBase . '#' : '#';
+
+$navSections = [
+    'inicio' => 'Inicio',
+    'menu' => 'Menú',
+    'nosotros' => 'Nosotros',
+    'testimonios' => 'Testimonio',
+];
+
+$navExtraSections = [
+    'puntos' => 'Puntos',
+    'ubicacion' => 'Ubicación',
+    'contacto' => 'Contacto',
+];
+?>
+<nav class="navbar navbar-expand-lg navbar-dark sticky-navbar bg-dark">
+  <div class="container">
+    <a class="navbar-brand" href="<?= htmlspecialchars($navHomeLink, ENT_QUOTES, 'UTF-8'); ?>">
+      <i class="fas fa-utensils"></i> <?= htmlspecialchars($navBrandLabel, ENT_QUOTES, 'UTF-8'); ?>
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <?php foreach ($navSections as $section => $label): ?>
+          <li class="nav-item"><a class="nav-link" href="<?= htmlspecialchars($sectionLinkPrefix . $section, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?></a></li>
+        <?php endforeach; ?>
+
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="extrasDropdown" role="button" data-bs-toggle="dropdown">
+            Más
+          </a>
+          <ul class="dropdown-menu dropdown-menu-dark">
+            <?php foreach ($navExtraSections as $section => $label): ?>
+              <li><a class="dropdown-item" href="<?= htmlspecialchars($sectionLinkPrefix . $section, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?></a></li>
+            <?php endforeach; ?>
+          </ul>
+        </li>
+
+        <li class="nav-item">
+          <a class="nav-link position-relative" href="<?= htmlspecialchars($navCarritoLink, ENT_QUOTES, 'UTF-8'); ?>">
+            <i class="fas fa-shopping-cart"></i>
+            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger cart-counter" id="contador-carrito">
+              0
+            </span>
+          </a>
+        </li>
+
+        <?php if (isset($_SESSION['cliente'])): ?>
+          <li class="nav-item">
+            <a href="cliente/perfil_cliente.php" class="nav-link" title="<?= htmlspecialchars($_SESSION['cliente']['nombre'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+              <i class="fas fa-user-circle"></i>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#" class="nav-link" title="Cerrar sesión" data-bs-toggle="modal" data-bs-target="#logoutModal">
+              <i class="fas fa-sign-out-alt"></i>
+            </a>
+          </li>
+        <?php else: ?>
+          <li class="nav-item">
+            <a href="cliente/login_cliente.php" class="btn btn-gold rounded-pill px-4 py-2 ms-2">
+              Iniciar sesión / Registrarse
+            </a>
+          </li>
+        <?php endif; ?>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="modal fade" id="logoutModal" tabindex="-1" aria-labelledby="logoutModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content bg-dark text-white border-0 shadow-lg">
+      <div class="modal-header border-bottom-0">
+        <h5 class="modal-title fw-bold" id="logoutModalLabel">
+          <i class="fas fa-sign-out-alt me-2 text-warning"></i> ¿Cerrar sesión?
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body text-center">
+        <p class="fs-5 mb-0">¿Estás seguro de que querés cerrar sesión?</p>
+      </div>
+      <div class="modal-footer justify-content-center border-top-0">
+        <button type="button" class="btn btn-success px-4" data-bs-dismiss="modal">
+          <i></i> Quedarme
+        </button>
+        <a href="cliente/logout_cliente.php" class="btn btn-danger px-4">
+          <i class="fas fa-door-open me-1"></i> Cerrar Sesión
+        </a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- move repeated head markup into a reusable partial that allows per-page titles and styles
- add a session-aware navbar partial and include it wherever the navigation appears
- update the index, cart, and confirm views to use the new partials while preserving page-specific assets and actions

## Testing
- php -l views/partials/head.php
- php -l views/partials/navbar.php
- php -l views/index.view.php
- php -l views/carrito.view.php
- php -l views/confirmar_pedido.view.php

------
https://chatgpt.com/codex/tasks/task_e_68c88f26c18483239bb7959556ee7a18